### PR TITLE
removed direct logging to console in stand-alone server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can use the language server component of this repository without the vscode-
 
 To use the language server standalone, run
 
-- `node server/out/server.js`
+- `node server/out/server.js --stdio`
 
 ## Structure
 

--- a/server/src/Parser.ts
+++ b/server/src/Parser.ts
@@ -2,6 +2,7 @@ import Parser, { SyntaxNode } from "tree-sitter";
 import { Diagnostic } from "vscode-languageserver";
 import ScopeNode, { DeclaredType } from "./node/ScopeNode";
 import parse from "./tree-sitter-p4/parse";
+import { logInfo } from "./utils/Logger"
 
 const BlockScopeNodeTypes = new Set<string>()
   .add("blockStatement")
@@ -106,7 +107,7 @@ const collectTypesInScopeNodes = (rootNode: Parser.SyntaxNode): ScopeNode => {
       const child0 = tree.namedChild(0);
       const child1 = tree.namedChild(1);
       if (child1) {
-        console.log(child1.text, currentBlockScope.type);
+        logInfo(child1.text + "(type: " + currentBlockScope.type + ")");
         currentBlockScope.addDeclaredType({
           type: "constant",
           identifier: child1.text,
@@ -189,7 +190,7 @@ export function parseSource(
 ): { scopeTreeRoot: ScopeNode; parseTreeRoot: Parser.SyntaxNode } {
   const parseTreeRoot = parse(source);
   const scopeTreeRoot = collectTypesInScopeNodes(parseTreeRoot.rootNode);
-  console.log(JSON.stringify(createAST(parseTreeRoot.rootNode)));
+  logInfo(JSON.stringify(createAST(parseTreeRoot.rootNode)));
   return {
     scopeTreeRoot,
     parseTreeRoot: parseTreeRoot.rootNode,

--- a/server/src/Parser.ts
+++ b/server/src/Parser.ts
@@ -2,7 +2,7 @@ import Parser, { SyntaxNode } from "tree-sitter";
 import { Diagnostic } from "vscode-languageserver";
 import ScopeNode, { DeclaredType } from "./node/ScopeNode";
 import parse from "./tree-sitter-p4/parse";
-import { logInfo } from "./utils/Logger"
+import { logInfo } from "./utils/Logger";
 
 const BlockScopeNodeTypes = new Set<string>()
   .add("blockStatement")

--- a/server/src/TextDocumentManager.ts
+++ b/server/src/TextDocumentManager.ts
@@ -9,6 +9,7 @@ import { Range, TextDocument } from "vscode-languageserver-textdocument";
 import ScopeNode from "./node/ScopeNode";
 import { parseSource } from "./Parser";
 import Parser, { SyntaxNode } from "tree-sitter";
+import { logInfo } from "./utils/Logger"
 
 const nodeToDiagnostic = (node: SyntaxNode): Diagnostic => ({
   message: "test",
@@ -75,7 +76,7 @@ export default class TextDocumentManager {
       _textDocumentPosition.textDocument.uri
     );
     if (node) {
-      console.log("Found identifier to provide definition for: " + node.text);
+      logInfo("Found identifier to provide definition for: " + node.text);
       const rootScope = this.scopeRepresentation.get(
         _textDocumentPosition.textDocument.uri
       );

--- a/server/src/TextDocumentManager.ts
+++ b/server/src/TextDocumentManager.ts
@@ -9,7 +9,7 @@ import { Range, TextDocument } from "vscode-languageserver-textdocument";
 import ScopeNode from "./node/ScopeNode";
 import { parseSource } from "./Parser";
 import Parser, { SyntaxNode } from "tree-sitter";
-import { logInfo } from "./utils/Logger"
+import { logInfo } from "./utils/Logger";
 
 const nodeToDiagnostic = (node: SyntaxNode): Diagnostic => ({
   message: "test",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import {
+  Connection,
   createConnection,
   TextDocuments,
   Diagnostic,
@@ -21,186 +22,194 @@ import DefinitionProviderCreator from "./DefinitionProvider";
 import HoverProviderCreator from "./HoverProvider";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
-const documentManager = new TextdocumentManager();
-
-// Create a connection for the server, using Node's IPC as a transport.
-// Also include all preview / proposed LSP features.
-let connection = createConnection(ProposedFeatures.all);
-
-// Create a simple text document manager.
-let documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
-
-let hasConfigurationCapability: boolean = false;
-let hasWorkspaceFolderCapability: boolean = false;
-let hasDiagnosticRelatedInformationCapability: boolean = false;
-
-connection.onInitialize((params: InitializeParams) => {
-  let capabilities = params.capabilities;
-
-  // Does the client support the `workspace/configuration` request?
-  // If not, we fall back using global settings.
-  hasConfigurationCapability = !!(
-    capabilities.workspace && !!capabilities.workspace.configuration
-  );
-  hasWorkspaceFolderCapability = !!(
-    capabilities.workspace && !!capabilities.workspace.workspaceFolders
-  );
-  hasDiagnosticRelatedInformationCapability = !!(
-    capabilities.textDocument &&
-    capabilities.textDocument.publishDiagnostics &&
-    capabilities.textDocument.publishDiagnostics.relatedInformation
-  );
-
-  const result: InitializeResult = {
-    capabilities: {
-      textDocumentSync: TextDocumentSyncKind.Incremental,
-      // Tell the client that this server supports code completion.
-      completionProvider: {
-        resolveProvider: true,
-      },
-      definitionProvider: true,
-      hoverProvider: true,
-    },
-  };
-  if (hasWorkspaceFolderCapability) {
-    result.capabilities.workspace = {
-      workspaceFolders: {
-        supported: true,
-      },
-    };
-  }
-  return result;
-});
-
-connection.onInitialized(() => {
-  if (hasConfigurationCapability) {
-    // Register for all configuration changes.
-    connection.client.register(
-      DidChangeConfigurationNotification.type,
-      undefined
-    );
-  }
-  if (hasWorkspaceFolderCapability) {
-    connection.workspace.onDidChangeWorkspaceFolders((_event) => {
-      connection.console.log("Workspace folder change event received.");
-    });
-  }
-});
-
 // The example settings
 interface ExampleSettings {
   maxNumberOfProblems: number;
 }
 
-// The global settings, used when the `workspace/configuration` request is not supported by the client.
-// Please note that this is not the case when using this server with the client provided in this example
-// but could happen with other clients.
-const defaultSettings: ExampleSettings = { maxNumberOfProblems: 1000 };
-let globalSettings: ExampleSettings = defaultSettings;
+class P4LanguageServer {
+  public connection: Connection;
 
-// Cache the settings of all open documents
-let documentSettings: Map<string, Thenable<ExampleSettings>> = new Map();
+  // Create a simple text document manager.
+  private documentManager = new TextdocumentManager();
+  private documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
 
-connection.onDidChangeConfiguration((change) => {
-  if (hasConfigurationCapability) {
-    // Reset all cached document settings
-    documentSettings.clear();
-  } else {
-    globalSettings = <ExampleSettings>(
-      (change.settings.languageServerExample || defaultSettings)
-    );
-  }
+  // The global settings, used when the `workspace/configuration` request is not supported by the client.
+  // Please note that this is not the case when using this server with the client provided in this example
+  // but could happen with other clients.
+  private defaultSettings: ExampleSettings = { maxNumberOfProblems: 1000 };
+  private globalSettings: ExampleSettings = this.defaultSettings;
 
-  // Revalidate all open text documents
-  documents.all().forEach(validateTextDocument);
-});
+  // Cache the settings of all open documents
+  private documentSettings: Map<string, Thenable<ExampleSettings>> = new Map();
+ 
+  private hasConfigurationCapability: boolean = false;
+  private hasWorkspaceFolderCapability: boolean = false;
+  private hasDiagnosticRelatedInformationCapability: boolean = false;
 
-function getDocumentSettings(resource: string): Thenable<ExampleSettings> {
-  if (!hasConfigurationCapability) {
-    return Promise.resolve(globalSettings);
-  }
-  let result = documentSettings.get(resource);
-  if (!result) {
-    result = connection.workspace.getConfiguration({
-      scopeUri: resource,
-      section: "languageServerExample",
+  constructor() {
+    // Create a connection for the server, using Node's IPC as a transport.
+    // Also include all preview / proposed LSP features.
+    this.connection = createConnection(ProposedFeatures.all);
+
+    this.connection.onInitialize((params: InitializeParams) => {
+      let capabilities = params.capabilities;
+    
+      // Does the client support the `workspace/configuration` request?
+      // If not, we fall back using global settings.
+      this.hasConfigurationCapability = !!(
+        capabilities.workspace && !!capabilities.workspace.configuration
+      );
+      this.hasWorkspaceFolderCapability = !!(
+        capabilities.workspace && !!capabilities.workspace.workspaceFolders
+      );
+      this.hasDiagnosticRelatedInformationCapability = !!(
+        capabilities.textDocument &&
+        capabilities.textDocument.publishDiagnostics &&
+        capabilities.textDocument.publishDiagnostics.relatedInformation
+      );
+    
+      const result: InitializeResult = {
+        capabilities: {
+          textDocumentSync: TextDocumentSyncKind.Incremental,
+          // Tell the client that this server supports code completion.
+          completionProvider: {
+            resolveProvider: true,
+          },
+          definitionProvider: true,
+          hoverProvider: true,
+        },
+      };
+      if (this.hasWorkspaceFolderCapability) {
+        result.capabilities.workspace = {
+          workspaceFolders: {
+            supported: true,
+          },
+        };
+      }
+      return result;
     });
-    documentSettings.set(resource, result);
+
+    this.connection.onInitialized(() => {
+      if (this.hasConfigurationCapability) {
+        // Register for all configuration changes.
+        this.connection.client.register(
+          DidChangeConfigurationNotification.type,
+          undefined
+        );
+      }
+      if (this.hasWorkspaceFolderCapability) {
+        this.connection.workspace.onDidChangeWorkspaceFolders((_event) => {
+          this.connection.console.log("Workspace folder change event received.");
+        });
+      }
+    });
+
+    this.connection.onDidChangeConfiguration((change) => {
+      if (this.hasConfigurationCapability) {
+        // Reset all cached document settings
+        this.documentSettings.clear();
+      } else {
+        this.globalSettings = <ExampleSettings>(
+          (change.settings.languageServerExample || this.defaultSettings)
+        );
+      }
+    
+    });    
+
+ 
+    // Only keep settings for open documents
+    this.documents.onDidClose((e) => {
+      this.documentSettings.delete(e.document.uri);
+    });
+    
+    // The content of a text document has changed. This event is emitted
+    // when the text document first opened or when its content has changed.
+    this.documents.onDidChangeContent((change) => {
+      this.validateTextDocument(change.document);
+    });
+    
+  
+    this.connection.onDidChangeWatchedFiles((_change) => {
+      // Monitored files have change in VSCode
+      this.connection.console.log("We received an file change event");
+    });
+    
+    this.connection.onDefinition(DefinitionProviderCreator(this.documentManager));
+    this.connection.onHover(HoverProviderCreator(this.documentManager));
+    
+    // This handler provides the initial list of the completion items.
+    this.connection.onCompletion(
+      (_textDocumentPosition: TextDocumentPositionParams): CompletionItem[] => {
+        // The pass parameter contains the position of the text document in
+        // which code complete got requested. For the example we ignore this
+        // info and always provide the same completion items.
+        return [
+          {
+            label: "TypeScript",
+            kind: CompletionItemKind.Text,
+            data: 1,
+          },
+          {
+            label: "JavaScript",
+            kind: CompletionItemKind.Text,
+            data: 2,
+          },
+        ];
+      }
+    );
+    
+    // This handler resolves additional information for the item selected in
+    // the completion list.
+    this.connection.onCompletionResolve(
+      (item: CompletionItem): CompletionItem => {
+        if (item.data === 1) {
+          item.detail = "TypeScript details";
+          item.documentation = "TypeScript documentation";
+        } else if (item.data === 2) {
+          item.detail = "JavaScript details";
+          item.documentation = "JavaScript documentation";
+        }
+        return item;
+      }
+    );
+    
+    // Make the text document manager listen on the connection
+    // for open, change and close text document events
+    this.documents.listen(this.connection);
+    
+    // Listen on the connection
+    this.connection.listen();
+
   }
-  return result;
-}
 
-// Only keep settings for open documents
-documents.onDidClose((e) => {
-  documentSettings.delete(e.document.uri);
-});
-
-// The content of a text document has changed. This event is emitted
-// when the text document first opened or when its content has changed.
-documents.onDidChangeContent((change) => {
-  validateTextDocument(change.document);
-});
-
-async function validateTextDocument(textDocument: TextDocument): Promise<void> {
-  let settings = await getDocumentSettings(textDocument.uri);
-  let diagnostics: Diagnostic[] = [];
-  try {
-    diagnostics = [...documentManager.update(textDocument)];
-  } catch (ex) {
-    console.log(ex);
-  }
-
-  // Send the computed diagnostics to VSCode.
-  connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });
-}
-
-connection.onDidChangeWatchedFiles((_change) => {
-  // Monitored files have change in VSCode
-  connection.console.log("We received an file change event");
-});
-
-connection.onDefinition(DefinitionProviderCreator(documentManager));
-connection.onHover(HoverProviderCreator(documentManager));
-
-// This handler provides the initial list of the completion items.
-connection.onCompletion(
-  (_textDocumentPosition: TextDocumentPositionParams): CompletionItem[] => {
-    // The pass parameter contains the position of the text document in
-    // which code complete got requested. For the example we ignore this
-    // info and always provide the same completion items.
-    return [
-      {
-        label: "TypeScript",
-        kind: CompletionItemKind.Text,
-        data: 1,
-      },
-      {
-        label: "JavaScript",
-        kind: CompletionItemKind.Text,
-        data: 2,
-      },
-    ];
-  }
-);
-
-// This handler resolves additional information for the item selected in
-// the completion list.
-connection.onCompletionResolve(
-  (item: CompletionItem): CompletionItem => {
-    if (item.data === 1) {
-      item.detail = "TypeScript details";
-      item.documentation = "TypeScript documentation";
-    } else if (item.data === 2) {
-      item.detail = "JavaScript details";
-      item.documentation = "JavaScript documentation";
+  getDocumentSettings(resource: string): Thenable<ExampleSettings> {
+    if (!this.hasConfigurationCapability) {
+      return Promise.resolve(this.globalSettings);
     }
-    return item;
+    let result = this.documentSettings.get(resource);
+    if (!result) {
+      result = this.connection.workspace.getConfiguration({
+        scopeUri: resource,
+        section: "languageServerExample",
+      });
+      this.documentSettings.set(resource, result);
+    }
+    return result;
   }
-);
 
-// Make the text document manager listen on the connection
-// for open, change and close text document events
-documents.listen(connection);
+  async validateTextDocument(textDocument: TextDocument): Promise<void> {
+    let settings = await this.getDocumentSettings(textDocument.uri);
+    let diagnostics: Diagnostic[] = [];
+    try {
+      diagnostics = [...this.documentManager.update(textDocument)];
+    } catch (ex) {
+      this.connection.console.log(ex);
+    }
+  
+    // Send the computed diagnostics to VSCode.
+    this.connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });
+  }
+}
 
-// Listen on the connection
-connection.listen();
+export const P4LanguageServerInstance = new P4LanguageServer();

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -32,7 +32,9 @@ class P4LanguageServer {
 
   // Create a simple text document manager.
   private documentManager = new TextdocumentManager();
-  private documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
+  private documents: TextDocuments<TextDocument> = new TextDocuments(
+    TextDocument
+  );
 
   // The global settings, used when the `workspace/configuration` request is not supported by the client.
   // Please note that this is not the case when using this server with the client provided in this example
@@ -42,7 +44,7 @@ class P4LanguageServer {
 
   // Cache the settings of all open documents
   private documentSettings: Map<string, Thenable<ExampleSettings>> = new Map();
- 
+
   private hasConfigurationCapability: boolean = false;
   private hasWorkspaceFolderCapability: boolean = false;
   private hasDiagnosticRelatedInformationCapability: boolean = false;
@@ -54,7 +56,7 @@ class P4LanguageServer {
 
     this.connection.onInitialize((params: InitializeParams) => {
       let capabilities = params.capabilities;
-    
+
       // Does the client support the `workspace/configuration` request?
       // If not, we fall back using global settings.
       this.hasConfigurationCapability = !!(
@@ -68,7 +70,7 @@ class P4LanguageServer {
         capabilities.textDocument.publishDiagnostics &&
         capabilities.textDocument.publishDiagnostics.relatedInformation
       );
-    
+
       const result: InitializeResult = {
         capabilities: {
           textDocumentSync: TextDocumentSyncKind.Incremental,
@@ -100,7 +102,9 @@ class P4LanguageServer {
       }
       if (this.hasWorkspaceFolderCapability) {
         this.connection.workspace.onDidChangeWorkspaceFolders((_event) => {
-          this.connection.console.log("Workspace folder change event received.");
+          this.connection.console.log(
+            "Workspace folder change event received."
+          );
         });
       }
     });
@@ -114,30 +118,29 @@ class P4LanguageServer {
           (change.settings.languageServerExample || this.defaultSettings)
         );
       }
-    
-    });    
+    });
 
- 
     // Only keep settings for open documents
     this.documents.onDidClose((e) => {
       this.documentSettings.delete(e.document.uri);
     });
-    
+
     // The content of a text document has changed. This event is emitted
     // when the text document first opened or when its content has changed.
     this.documents.onDidChangeContent((change) => {
       this.validateTextDocument(change.document);
     });
-    
-  
+
     this.connection.onDidChangeWatchedFiles((_change) => {
       // Monitored files have change in VSCode
       this.connection.console.log("We received an file change event");
     });
-    
-    this.connection.onDefinition(DefinitionProviderCreator(this.documentManager));
+
+    this.connection.onDefinition(
+      DefinitionProviderCreator(this.documentManager)
+    );
     this.connection.onHover(HoverProviderCreator(this.documentManager));
-    
+
     // This handler provides the initial list of the completion items.
     this.connection.onCompletion(
       (_textDocumentPosition: TextDocumentPositionParams): CompletionItem[] => {
@@ -158,7 +161,7 @@ class P4LanguageServer {
         ];
       }
     );
-    
+
     // This handler resolves additional information for the item selected in
     // the completion list.
     this.connection.onCompletionResolve(
@@ -173,14 +176,13 @@ class P4LanguageServer {
         return item;
       }
     );
-    
+
     // Make the text document manager listen on the connection
     // for open, change and close text document events
     this.documents.listen(this.connection);
-    
+
     // Listen on the connection
     this.connection.listen();
-
   }
 
   getDocumentSettings(resource: string): Thenable<ExampleSettings> {
@@ -206,7 +208,7 @@ class P4LanguageServer {
     } catch (ex) {
       this.connection.console.log(ex);
     }
-  
+
     // Send the computed diagnostics to VSCode.
     this.connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });
   }

--- a/server/src/utils/Logger.ts
+++ b/server/src/utils/Logger.ts
@@ -1,41 +1,40 @@
-import { P4LanguageServerInstance } from "../server"
+import { P4LanguageServerInstance } from "../server";
 
 export enum LOGGER_MODE {
-	DEBUG, // < INFO
-	INFO, // < ERROR
-	ERROR, //
-	USER_LOG,
-  }
-  
-  export function log(msg: string, mode: LOGGER_MODE) {
-	P4LanguageServerInstance.connection.console.log(msg);
-  }
-  
-  export function logInfo(msg: string) {
-	// log(msg, LOGGER_MODE.INFO);
-  }
-  
-  export function logDebug(msg: string) {
-	log(msg, LOGGER_MODE.DEBUG);
-  }
-  
-  export function logError(msg: string) {
-	log(msg, LOGGER_MODE.ERROR);
-  }
-  
-  export function logDebugT(msg: string) {
-	const t: Date = new Date();
-	const time: string =
-	  "[" +
-	  t.getHours() +
-	  ":" +
-	  t.getMinutes() +
-	  ":" +
-	  t.getSeconds() +
-	  "." +
-	  (Date.now() % 1000) +
-	  "]  ";
-  
-	logDebug(time + msg);
-  }
+  DEBUG, // < INFO
+  INFO, // < ERROR
+  ERROR, //
+  USER_LOG,
+}
 
+export function log(msg: string, mode: LOGGER_MODE) {
+  P4LanguageServerInstance.connection.console.log(msg);
+}
+
+export function logInfo(msg: string) {
+  // log(msg, LOGGER_MODE.INFO);
+}
+
+export function logDebug(msg: string) {
+  log(msg, LOGGER_MODE.DEBUG);
+}
+
+export function logError(msg: string) {
+  log(msg, LOGGER_MODE.ERROR);
+}
+
+export function logDebugT(msg: string) {
+  const t: Date = new Date();
+  const time: string =
+    "[" +
+    t.getHours() +
+    ":" +
+    t.getMinutes() +
+    ":" +
+    t.getSeconds() +
+    "." +
+    (Date.now() % 1000) +
+    "]  ";
+
+  logDebug(time + msg);
+}

--- a/server/src/utils/Logger.ts
+++ b/server/src/utils/Logger.ts
@@ -1,0 +1,41 @@
+import { P4LanguageServerInstance } from "../server"
+
+export enum LOGGER_MODE {
+	DEBUG, // < INFO
+	INFO, // < ERROR
+	ERROR, //
+	USER_LOG,
+  }
+  
+  export function log(msg: string, mode: LOGGER_MODE) {
+	P4LanguageServerInstance.connection.console.log(msg);
+  }
+  
+  export function logInfo(msg: string) {
+	// log(msg, LOGGER_MODE.INFO);
+  }
+  
+  export function logDebug(msg: string) {
+	log(msg, LOGGER_MODE.DEBUG);
+  }
+  
+  export function logError(msg: string) {
+	log(msg, LOGGER_MODE.ERROR);
+  }
+  
+  export function logDebugT(msg: string) {
+	const t: Date = new Date();
+	const time: string =
+	  "[" +
+	  t.getHours() +
+	  ":" +
+	  t.getMinutes() +
+	  ":" +
+	  t.getSeconds() +
+	  "." +
+	  (Date.now() % 1000) +
+	  "]  ";
+  
+	logDebug(time + msg);
+  }
+


### PR DESCRIPTION
Using the stand-alone server with jsonrpc-ws-proxy led to "Content-Length header" missing which boiled down to console.log being used. Maybe an option to move arround this could be the suggested PR, chaning server.ts to expose a class member var that holds the connection and using this instance to send log messages. 

With these changes, or when commenting out the console.log portions, server runs fine and can be used with the monaco languageclient frontend. However, it only seems to offer to default code completions (.JavaScript and .TypeScript, as defined in the server.ts code) and a "test" message on hover. Maybe there is still some code missing in the stand-alone server or I forgot to build something? However, npm install & npm run compile:ls ran fine. BTW Thanks for the short docu in the README. Took some time to understand the build script and installation of tree-sitter before.